### PR TITLE
SchemaProcessor/string/v1: suporte a default value

### DIFF
--- a/schemaProcessor/string/v1/processor/main.tf
+++ b/schemaProcessor/string/v1/processor/main.tf
@@ -1,0 +1,83 @@
+locals {
+  declared_default_field        = contains(keys(var.manifest), "default")
+  has_compatible_default_value  = can(tostring(try(var.manifest.default, null)))
+}
+
+output "schema" {
+  value = {
+    type    = "string"
+    version = "v1"
+    subItem = null
+    validations = {
+      minLength         = try(tonumber(var.manifest.minLength), null)
+      maxLength         = try(tonumber(var.manifest.maxLength), null)
+      has_default_value = can(var.manifest.default) ? true : false
+      default_value     = try(tostring(var.manifest.default), null)
+    }
+  }
+
+  precondition {
+    condition     = can(tonumber(try(var.manifest.minLength, null)))
+    error_message = <<-EOT
+      Invalid "minLength" value.
+      The field "${var.field_path}.minLength" must be a number.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(tonumber(var.manifest.minLength) >= 0, true)
+    error_message = <<-EOT
+      Invalid "minLength" value.
+      The field "${var.field_path}.minLength" must be greater than or equal to 0.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(tonumber(try(var.manifest.maxLength, null)))
+    error_message = <<-EOT
+      Invalid "maxLength" value.
+      The field "${var.field_path}.maxLength" must be a number.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(tonumber(var.manifest.maxLength) >= 1, true)
+    error_message = <<-EOT
+      Invalid "maxLength" value.
+      The field "${var.field_path}.maxLength" must be greater than or equal to 1.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(var.manifest.minLength < var.manifest.maxLength, true)
+    error_message = <<-EOT
+      Invalid "minLength" and "maxLength" values.
+      The field "${var.field_path}.minLength" must be less than "${var.field_path}.maxLength".
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition = !(local.declared_default_field && try(var.manifest.default, null) == null)
+    error_message = <<-EOT
+      Invalid Manifest!
+      The default value of a string field can't be null.
+      The field "${var.field_path}" has its default value set to null.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = local.has_compatible_default_value
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The default value of the property "${var.field_path}" must be compatible with type string.
+      Current default value: ${format("%v", try(var.manifest.default, "null"))}
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaProcessor/string/v1/processor/variables.tf
+++ b/schemaProcessor/string/v1/processor/variables.tf
@@ -1,0 +1,15 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}

--- a/schemaProcessor/string/v1/validator/main.tf
+++ b/schemaProcessor/string/v1/validator/main.tf
@@ -1,0 +1,50 @@
+locals {
+  has_default_value = var.schema.validations.has_default_value
+  value             = var.manifest != null ? try(tostring(var.manifest), null) : var.schema.validations.default_value
+  minLength         = var.schema.validations.minLength != null ? var.schema.validations.minLength : 0
+  maxLength         = var.schema.validations.maxLength != null ? var.schema.validations.maxLength : 0
+  manifestLength    = try(length(local.value), 0)
+}
+
+output "resource" {
+  value = local.value
+
+  precondition {
+    condition = !(
+      !local.has_default_value
+      && var.manifest == null
+    )
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The property "${var.field_path}" can not be null and have no default value.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(tostring(var.manifest))
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The type of the property "${var.field_path}" must be string.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(length(var.manifest) >= var.schema.validations.minLength, true)
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The minimum length of the property "${var.field_path}" must be ${local.minLength} (got: ${local.manifestLength}).
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(length(var.manifest) <= var.schema.validations.maxLength, true)
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The maximum length of the property "${var.field_path}" must be ${local.maxLength} (got: ${local.manifestLength}).
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaProcessor/string/v1/validator/variables.tf
+++ b/schemaProcessor/string/v1/validator/variables.tf
@@ -1,0 +1,19 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}
+
+variable "schema" {
+  type = any
+}

--- a/schemaValidation/string/main.tf
+++ b/schemaValidation/string/main.tf
@@ -9,6 +9,22 @@ module "v0" {
   schema        = var.schema
 }
 
+module "v1" {
+  source = "../../schemaProcessor/string/v1/validator/"
+  count  = var.schema.version == "v1" ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = var.field_path
+  manifest      = var.manifest
+  schema        = var.schema
+}
+
 output "resource" {
-  value = one(module.v0[*].resource)
+  value = one(
+    concat(
+      module.v0[*].resource,
+      module.v1[*].resource,
+    )
+  )
 }

--- a/tests/schemaProcessor_string_v1_integration.tftest.hcl
+++ b/tests/schemaProcessor_string_v1_integration.tftest.hcl
@@ -1,0 +1,130 @@
+run "required_field_with_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    manifest = {
+      type = "string"
+    }
+  }
+}
+
+run "required_field_manifest_provides_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.required_field_with_value.schema
+    manifest      = "hello"
+  }
+
+  assert {
+    condition     = output.resource == "hello"
+    error_message = "Error: did not return the provided value for a required field"
+  }
+}
+
+run "required_field_manifest_missing_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.required_field_with_value.schema
+    manifest      = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "optional_field_with_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    manifest = {
+      type    = "string"
+      default = "fallback"
+    }
+  }
+}
+
+run "optional_field_manifest_missing_uses_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_field_with_default.schema
+    manifest      = null
+  }
+
+  assert {
+    condition     = output.resource == "fallback"
+    error_message = "Error: did not use default value when field is absent"
+  }
+}
+
+run "optional_field_manifest_overrides_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_field_with_default.schema
+    manifest      = "provided"
+  }
+
+  assert {
+    condition     = output.resource == "provided"
+    error_message = "Error: replaced provided value with default"
+  }
+}
+
+run "optional_field_invalid_value_does_not_fall_back_to_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_field_with_default.schema
+    manifest      = { invalid = "object" }
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}

--- a/tests/schemaProcessor_string_v1_processor.tftest.hcl
+++ b/tests/schemaProcessor_string_v1_processor.tftest.hcl
@@ -1,0 +1,181 @@
+run "without_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "string"
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = null
+        maxLength         = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    error_message = "Error when parsing string field without default value"
+  }
+}
+
+run "with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "string"
+      default = "hello"
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = null
+        maxLength         = null
+        has_default_value = true
+        default_value     = "hello"
+      }
+    }
+    error_message = "Error when parsing string field with default value"
+  }
+}
+
+run "with_default_value_and_constraints" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type      = "string"
+      minLength = 1
+      maxLength = 10
+      default   = "hello"
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = 1
+        maxLength         = 10
+        has_default_value = true
+        default_value     = "hello"
+      }
+    }
+    error_message = "Error when parsing string field with default value and constraints"
+  }
+}
+
+run "with_null_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "string"
+      default = null
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_minLength" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type      = "string"
+      minLength = "invalid"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_maxLength" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type      = "string"
+      maxLength = "invalid"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_minLength_and_maxLength" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type      = "string"
+      minLength = 10
+      maxLength = 5
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}

--- a/tests/schemaProcessor_string_v1_validator.tftest.hcl
+++ b/tests/schemaProcessor_string_v1_validator.tftest.hcl
@@ -1,0 +1,205 @@
+run "without_field_value_without_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = null
+        maxLength         = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_invalid_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = null
+        maxLength         = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = { invalid = "object" }
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_valid_value_without_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = null
+        maxLength         = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = "hello"
+  }
+
+  assert {
+    condition     = output.resource == "hello"
+    error_message = "Error: did not return the provided value"
+  }
+}
+
+run "without_field_value_with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = null
+        maxLength         = null
+        has_default_value = true
+        default_value     = "default-value"
+      }
+    }
+    manifest = null
+  }
+
+  assert {
+    condition     = output.resource == "default-value"
+    error_message = "Error: did not return the default value when field is absent"
+  }
+}
+
+run "with_valid_value_overrides_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = null
+        maxLength         = null
+        has_default_value = true
+        default_value     = "default-value"
+      }
+    }
+    manifest = "provided-value"
+  }
+
+  assert {
+    condition     = output.resource == "provided-value"
+    error_message = "Error: replaced provided value with default"
+  }
+}
+
+run "with_minLength_violation" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = 5
+        maxLength         = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = "hi"
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_maxLength_violation" {
+  command = plan
+  module {
+    source = "./schemaProcessor/string/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "string"
+      version = "v1"
+      subItem = null
+      validations = {
+        minLength         = null
+        maxLength         = 3
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = "toolong"
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}


### PR DESCRIPTION
## Summary

- Implementa `schemaProcessor/string/v1/processor` — adiciona suporte a `default` value opcional, mantendo todas as validações de `minLength`/`maxLength` do v0
- Implementa `schemaProcessor/string/v1/validator` — usa o `default_value` quando o campo está ausente no manifesto; campo sem default continua obrigatório (comportamento idêntico ao v0)
- Atualiza `schemaValidation/string/main.tf` para rotear schemas `version = "v1"` para o novo validator

## Comportamento

Campo sem `default` no CRD → comportamento idêntico ao v0 (campo obrigatório no manifesto do usuário). A adição de `default` é puramente aditiva — não quebra quem já usa `string` hoje.

## Test plan

- [x] 206/206 tests passing