### PR TITLE
schemaProcessor/integer/v1: suporte a default value

### DIFF
--- a/schemaProcessor/integer/v1/processor/main.tf
+++ b/schemaProcessor/integer/v1/processor/main.tf
@@ -1,0 +1,65 @@
+locals {
+  declared_default_field       = contains(keys(var.manifest), "default")
+  has_compatible_default_value = can(tonumber(try(var.manifest.default, null)))
+}
+
+output "schema" {
+  value = {
+    type    = "integer"
+    version = "v1"
+    subItem = null
+    validations = {
+      minimum           = try(tonumber(var.manifest.minimum), null)
+      maximum           = try(tonumber(var.manifest.maximum), null)
+      has_default_value = can(var.manifest.default) ? true : false
+      default_value     = try(tonumber(var.manifest.default), null)
+    }
+  }
+
+  precondition {
+    condition     = can(tonumber(try(var.manifest.minimum, null)))
+    error_message = <<-EOT
+      Invalid "minimum" value.
+      The field "${var.field_path}.minimum" must be a number.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(tonumber(try(var.manifest.maximum, null)))
+    error_message = <<-EOT
+      Invalid "maximum" value.
+      The field "${var.field_path}.maximum" must be a number.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(var.manifest.minimum < var.manifest.maximum, true)
+    error_message = <<-EOT
+      Invalid "minimum" and "maximum" values.
+      The field "${var.field_path}.minimum" must be less than "${var.field_path}.maximum".
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition = !(local.declared_default_field && try(var.manifest.default, null) == null)
+    error_message = <<-EOT
+      Invalid Manifest!
+      The default value of an integer field can't be null.
+      The field "${var.field_path}" has its default value set to null.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = local.has_compatible_default_value
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The default value of the property "${var.field_path}" must be compatible with type integer.
+      Current default value: ${format("%v", try(var.manifest.default, "null"))}
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaProcessor/integer/v1/processor/variables.tf
+++ b/schemaProcessor/integer/v1/processor/variables.tf
@@ -1,0 +1,15 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}

--- a/schemaProcessor/integer/v1/validator/main.tf
+++ b/schemaProcessor/integer/v1/validator/main.tf
@@ -1,0 +1,50 @@
+locals {
+  has_default_value  = var.schema.validations.has_default_value
+  value              = var.manifest != null ? try(tonumber(var.manifest), null) : var.schema.validations.default_value
+  minimum            = var.schema.validations.minimum != null ? var.schema.validations.minimum : 0
+  maximum            = var.schema.validations.maximum != null ? var.schema.validations.maximum : 0
+  value_for_display  = local.value != null ? local.value : "null"
+}
+
+output "resource" {
+  value = local.value
+
+  precondition {
+    condition = !(
+      !local.has_default_value
+      && var.manifest == null
+    )
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The property "${var.field_path}" can not be null and have no default value.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(tonumber(var.manifest))
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The type of the property "${var.field_path}" must be integer.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(var.manifest >= var.schema.validations.minimum, true)
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The value of the property "${var.field_path}" must be greater than or equal to ${local.minimum} (got: ${local.value_for_display}).
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(var.manifest <= var.schema.validations.maximum, true)
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The value of the property "${var.field_path}" must be less than or equal to ${local.maximum} (got: ${local.value_for_display}).
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaProcessor/integer/v1/validator/variables.tf
+++ b/schemaProcessor/integer/v1/validator/variables.tf
@@ -1,0 +1,19 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}
+
+variable "schema" {
+  type = any
+}

--- a/schemaValidation/integer/main.tf
+++ b/schemaValidation/integer/main.tf
@@ -9,6 +9,22 @@ module "v0" {
   schema        = var.schema
 }
 
+module "v1" {
+  source = "../../schemaProcessor/integer/v1/validator/"
+  count  = var.schema.version == "v1" ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = var.field_path
+  manifest      = var.manifest
+  schema        = var.schema
+}
+
 output "resource" {
-  value = one(module.v0[*].resource)
+  value = one(
+    concat(
+      module.v0[*].resource,
+      module.v1[*].resource,
+    )
+  )
 }

--- a/tests/schemaProcessor_integer_v1_integration.tftest.hcl
+++ b/tests/schemaProcessor_integer_v1_integration.tftest.hcl
@@ -1,0 +1,180 @@
+run "required_field_with_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    manifest = {
+      type = "integer"
+    }
+  }
+}
+
+run "required_field_with_value_validate" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    schema        = run.required_field_with_value.schema
+    manifest      = 3
+  }
+
+  assert {
+    condition     = output.resource == 3
+    error_message = "Error: provided value was not returned as-is"
+  }
+}
+
+run "required_field_missing" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    manifest = {
+      type = "integer"
+    }
+  }
+}
+
+run "required_field_missing_validate" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    schema        = run.required_field_missing.schema
+    manifest      = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "optional_field_missing_uses_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    manifest = {
+      type    = "integer"
+      default = 1
+    }
+  }
+}
+
+run "optional_field_missing_uses_default_validate" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    schema        = run.optional_field_missing_uses_default.schema
+    manifest      = null
+  }
+
+  assert {
+    condition     = output.resource == 1
+    error_message = "Error: default value was not used when field is absent"
+  }
+}
+
+run "optional_field_overrides_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    manifest = {
+      type    = "integer"
+      default = 1
+    }
+  }
+}
+
+run "optional_field_overrides_default_validate" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    schema        = run.optional_field_overrides_default.schema
+    manifest      = 5
+  }
+
+  assert {
+    condition     = output.resource == 5
+    error_message = "Error: provided value was replaced by default value"
+  }
+}
+
+run "invalid_value_does_not_fall_back_to_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    manifest = {
+      type    = "integer"
+      default = 1
+    }
+  }
+}
+
+run "invalid_value_does_not_fall_back_to_default_validate" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.replicas"
+    schema        = run.invalid_value_does_not_fall_back_to_default.schema
+    manifest      = "not-a-number"
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}

--- a/tests/schemaProcessor_integer_v1_processor.tftest.hcl
+++ b/tests/schemaProcessor_integer_v1_processor.tftest.hcl
@@ -1,0 +1,202 @@
+run "without_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "integer"
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    error_message = "Error when parsing integer field without default value"
+  }
+}
+
+run "with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "integer"
+      default = 42
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = null
+        has_default_value = true
+        default_value     = 42
+      }
+    }
+    error_message = "Error when parsing integer field with default value"
+  }
+}
+
+run "with_default_value_and_constraints" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "integer"
+      minimum = 1
+      maximum = 100
+      default = 10
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = 1
+        maximum           = 100
+        has_default_value = true
+        default_value     = 10
+      }
+    }
+    error_message = "Error when parsing integer field with default value and constraints"
+  }
+}
+
+run "with_null_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "integer"
+      default = null
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_default_value_incompatible_with_type_integer" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "integer"
+      default = "not-a-number"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_minimum" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "integer"
+      minimum = "invalid"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_maximum" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "integer"
+      maximum = "invalid"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_minimum_and_maximum" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type    = "integer"
+      minimum = 10
+      maximum = 5
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}

--- a/tests/schemaProcessor_integer_v1_validator.tftest.hcl
+++ b/tests/schemaProcessor_integer_v1_validator.tftest.hcl
@@ -1,0 +1,234 @@
+run "without_field_value_without_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = null
+        default_value     = null
+        has_default_value = false
+      }
+    }
+    manifest = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_invalid_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = null
+        default_value     = null
+        has_default_value = false
+      }
+    }
+    manifest = "not-a-number"
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_invalid_value_with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = null
+        default_value     = 10
+        has_default_value = true
+      }
+    }
+    manifest = "not-a-number"
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_valid_value_without_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = null
+        default_value     = null
+        has_default_value = false
+      }
+    }
+    manifest = 42
+  }
+
+  assert {
+    condition     = output.resource == 42
+    error_message = "Error: did not fill the field with the valid provided value"
+  }
+}
+
+run "with_valid_value_with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = null
+        default_value     = 10
+        has_default_value = true
+      }
+    }
+    manifest = 42
+  }
+
+  assert {
+    condition     = output.resource == 42
+    error_message = "Error: replaced provided value with default value"
+  }
+}
+
+run "without_field_value_with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = null
+        default_value     = 10
+        has_default_value = true
+      }
+    }
+    manifest = null
+  }
+
+  assert {
+    condition     = output.resource == 10
+    error_message = "Error: did not use default value when field is absent"
+  }
+}
+
+run "with_value_below_minimum" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = 5
+        maximum           = null
+        default_value     = null
+        has_default_value = false
+      }
+    }
+    manifest = 2
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_value_above_maximum" {
+  command = plan
+  module {
+    source = "./schemaProcessor/integer/v1/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "integer"
+      version = "v1"
+      subItem = null
+      validations = {
+        minimum           = null
+        maximum           = 100
+        default_value     = null
+        has_default_value = false
+      }
+    }
+    manifest = 200
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}


### PR DESCRIPTION
## O que esse PR faz

Implementa `schemaProcessor/integer/v1` com suporte ao campo `default` opcional nos CRDs.

Quando o CRD não declara `default`, o campo se comporta exatamente como no `v0` (obrigatório). Quando `default` está presente, o manifesto do usuário pode omitir o campo e o valor padrão é aplicado automaticamente.

## Estrutura

- `schemaProcessor/integer/v1/processor/` — lê o CRD e emite schema com `version = "v1"`, incluindo `has_default_value` e `default_value`
- `schemaProcessor/integer/v1/validator/` — valida o manifesto do usuário contra o schema, aplicando o default quando necessário
- `schemaValidation/integer/main.tf` — atualizado para rotear para o validator v1 quando `schema.version == "v1"`

## Testes

- `tests/schemaProcessor_integer_v1_processor.tftest.hcl` — testes unitários do processor (sem default, com default, default nulo, default incompatível, minimum/maximum inválidos)
- `tests/schemaProcessor_integer_v1_validator.tftest.hcl` — testes unitários do validator (campo obrigatório ausente, valor inválido, valor válido, default aplicado, violação de minimum/maximum)
- `tests/schemaProcessor_integer_v1_integration.tftest.hcl` — testes encadeados processor→validator que verificam o contrato completo (campo obrigatório, campo opcional com default, valor inválido não cai no default)