### PR TITLE
schemaProcessor/array/v2: adiciona suporte a default value

### DIFF
--- a/schemaProcessor/array/v2/processor/main.tf
+++ b/schemaProcessor/array/v2/processor/main.tf
@@ -1,0 +1,166 @@
+locals {
+  declared_default_field       = contains(keys(var.manifest), "default")
+  has_compatible_default_value = can(tolist(try(var.manifest.default, null)))
+}
+
+module "string" {
+  source = "../../../string/v1/processor"
+  count  = try(var.manifest.items.type == "string", false) ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.items"
+  manifest      = var.manifest.items
+}
+
+module "integer" {
+  source = "../../../integer/v1/processor"
+  count  = try(var.manifest.items.type == "integer", false) ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.items"
+  manifest      = var.manifest.items
+}
+
+module "bool" {
+  source = "../../../bool/v1/processor"
+
+  count = try(var.manifest.items.type == "bool", false) ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.items"
+  manifest      = var.manifest.items
+}
+
+module "reduced_object" {
+  source = "../../../reduced_object/v2/processor"
+  count  = try(var.manifest.items.type == "object", false) ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.items"
+  manifest      = var.manifest.items
+}
+
+output "schema" {
+  value = {
+    type    = "array"
+    version = "v2"
+    subItem = one(flatten([
+      module.string[*].schema, module.integer[*].schema,
+      module.bool[*].schema, module.reduced_object[*].schema,
+    ]))
+    validations = {
+      minItems          = try(tonumber(var.manifest.minItems), null)
+      maxItems          = try(tonumber(var.manifest.maxItems), null)
+      has_default_value = can(var.manifest.default) ? true : false
+      default_value     = try(var.manifest.default, null)
+    }
+  }
+
+  precondition {
+    condition     = can(var.manifest.items)
+    error_message = <<-EOT
+      Invalid "items" value.
+      The field "${var.field_path}.items" are required.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = !can(var.manifest.items) || can(var.manifest.items.type)
+    error_message = <<-EOT
+      Invalid "items" value.
+      The field "${var.field_path}.items.type" are required.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition = !can(var.manifest.items) || !can(var.manifest.items.type) || try(
+      contains(["string", "integer", "bool", "object"], var.manifest.items.type),
+      true,
+    )
+    error_message = <<-EOT
+      Invalid "items.type" value.
+      The field "${var.field_path}.items.type" must be one of "string", "integer", "bool" or "object".
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(var.manifest.items.type)
+    error_message = <<-EOT
+      Invalid "items" value.
+      The field "${var.field_path}.items.type" are required.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(tonumber(try(var.manifest.minItems, null)))
+    error_message = <<-EOT
+      Invalid "minItems" value.
+      The field "${var.field_path}.minItems" must be a number.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(tonumber(var.manifest.minItems) >= 0, true)
+    error_message = <<-EOT
+      Invalid "minItems" value.
+      The field "${var.field_path}.minItems" must be greater than or equal to 0.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(tonumber(try(var.manifest.maxItems, null)))
+    error_message = <<-EOT
+      Invalid "maxItems" value.
+      The field "${var.field_path}.maxItems" must be a number.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(tonumber(var.manifest.maxItems) >= 1, true)
+    error_message = <<-EOT
+      Invalid "maxItems" value.
+      The field "${var.field_path}.maxItems" must be greater than or equal to 1.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(var.manifest.minItems < var.manifest.maxItems, true)
+    error_message = <<-EOT
+      Invalid "minItems" and "maxItems" values.
+      The field "${var.field_path}.minItems" must be less than "${var.field_path}.maxItems".
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = !(local.declared_default_field && try(var.manifest.default, null) == null)
+    error_message = <<-EOT
+      Invalid Manifest!
+      The default value of an array field can't be null.
+      The field "${var.field_path}" has its default value set to null.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = local.has_compatible_default_value
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The default value of the property "${var.field_path}" must be compatible with type array.
+      Current default value: ${format("%v", try(var.manifest.default, "null"))}
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaProcessor/array/v2/processor/variables.tf
+++ b/schemaProcessor/array/v2/processor/variables.tf
@@ -1,0 +1,15 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}

--- a/schemaProcessor/array/v2/validator/main.tf
+++ b/schemaProcessor/array/v2/validator/main.tf
@@ -1,0 +1,94 @@
+locals {
+  has_default_value = var.schema.validations.has_default_value
+  value             = var.manifest != null ? try(tolist(var.manifest), null) : try(tolist(var.schema.validations.default_value), null)
+  minItems          = var.schema.validations.minItems != null ? var.schema.validations.minItems : 0
+  maxItems          = var.schema.validations.maxItems != null ? var.schema.validations.maxItems : 0
+  manifestLength    = can(tolist(local.value)) ? try(length(local.value), 0) : 0
+}
+
+module "string" {
+  source = "../../../../schemaValidation/string/"
+  count  = var.schema.subItem.type == "string" ? local.manifestLength : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}[${count.index}]"
+  manifest      = local.value[count.index]
+  schema        = var.schema.subItem
+}
+
+module "bool" {
+  source = "../../../../schemaValidation/bool/"
+  count  = var.schema.subItem.type == "bool" ? local.manifestLength : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}[${count.index}]"
+  manifest      = local.value[count.index]
+  schema        = var.schema.subItem
+}
+
+module "integer" {
+  source = "../../../../schemaValidation/integer/"
+  count  = var.schema.subItem.type == "integer" ? local.manifestLength : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}[${count.index}]"
+  manifest      = local.value[count.index]
+  schema        = var.schema.subItem
+}
+
+module "reduced_object" {
+  source = "../../../../schemaValidation/reduced_object"
+  count  = var.schema.subItem.type == "reduced_object" ? local.manifestLength : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}[${count.index}]"
+  manifest      = local.value[count.index]
+  schema        = var.schema.subItem
+}
+
+output "resource" {
+  value = concat(module.string[*].resource, module.bool[*].resource, module.integer[*].resource, module.reduced_object[*].resource)
+
+  precondition {
+    condition = !(
+      !local.has_default_value
+      && var.manifest == null
+    )
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The property "${var.field_path}" can not be null and have no default value.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(tolist(var.manifest))
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The type of the property "${var.field_path}" must be list.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(length(var.manifest) >= var.schema.validations.minItems, true)
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The minimum items of the property "${var.field_path}" must be ${local.minItems} (got: ${local.manifestLength}).
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = try(length(var.manifest) <= var.schema.validations.maxItems, true)
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The minimum length of the property "${var.field_path}" must be ${local.maxItems} (got: ${local.manifestLength}).
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaProcessor/array/v2/validator/variables.tf
+++ b/schemaProcessor/array/v2/validator/variables.tf
@@ -1,0 +1,19 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}
+
+variable "schema" {
+  type = any
+}

--- a/schemaValidation/array/main.tf
+++ b/schemaValidation/array/main.tf
@@ -9,6 +9,22 @@ module "v0" {
   schema        = var.schema
 }
 
+module "v2" {
+  source = "../../schemaProcessor/array/v2/validator/"
+  count  = var.schema.version == "v2" ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = var.field_path
+  manifest      = var.manifest
+  schema        = var.schema
+}
+
 output "resource" {
-  value = one(module.v0[*].resource)
+  value = one(
+    concat(
+      module.v0[*].resource,
+      module.v2[*].resource,
+    )
+  )
 }

--- a/tests/schemaProcessor_array_v2_integration.tftest.hcl
+++ b/tests/schemaProcessor_array_v2_integration.tftest.hcl
@@ -1,0 +1,136 @@
+run "required_field_with_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    manifest = {
+      type = "array"
+      items = {
+        type = "bool"
+      }
+    }
+  }
+}
+
+run "required_field_manifest_provides_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.required_field_with_value.schema
+    manifest      = [true, false]
+  }
+
+  assert {
+    condition     = output.resource == [true, false]
+    error_message = "Error: did not return the provided value for a required field"
+  }
+}
+
+run "required_field_manifest_missing_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.required_field_with_value.schema
+    manifest      = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "optional_field_with_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    manifest = {
+      type = "array"
+      items = {
+        type = "bool"
+      }
+      default = [true]
+    }
+  }
+}
+
+run "optional_field_manifest_missing_uses_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_field_with_default.schema
+    manifest      = null
+  }
+
+  assert {
+    condition     = output.resource == [true]
+    error_message = "Error: did not use default value when field is absent"
+  }
+}
+
+run "optional_field_manifest_overrides_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_field_with_default.schema
+    manifest      = [false, false]
+  }
+
+  assert {
+    condition     = output.resource == [false, false]
+    error_message = "Error: replaced provided value with default"
+  }
+}
+
+run "optional_field_invalid_value_does_not_fall_back_to_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_field_with_default.schema
+    manifest      = { invalid = "object" }
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}

--- a/tests/schemaProcessor_array_v2_processor.tftest.hcl
+++ b/tests/schemaProcessor_array_v2_processor.tftest.hcl
@@ -1,0 +1,276 @@
+run "without_items" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "array"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "without_default_value_and_with_bool_items" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "array"
+      items = {
+        type = "bool"
+      }
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "bool"
+        version = "v1"
+        subItem = null
+        validations = {
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = null
+        maxItems          = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    error_message = "Error when parsing array field without default value"
+  }
+}
+
+run "with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "array"
+      items = {
+        type = "bool"
+      }
+      default = [true, false]
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "bool"
+        version = "v1"
+        subItem = null
+        validations = {
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = null
+        maxItems          = null
+        has_default_value = true
+        default_value     = [true, false]
+      }
+    }
+    error_message = "Error when parsing array field with default value"
+  }
+}
+
+run "with_default_value_and_constraints" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "array"
+      minItems = 1
+      maxItems = 3
+      items = {
+        type = "integer"
+      }
+      default = [1, 2]
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "integer"
+        version = "v1"
+        subItem = null
+        validations = {
+          minimum           = null
+          maximum           = null
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = 1
+        maxItems          = 3
+        has_default_value = true
+        default_value     = [1, 2]
+      }
+    }
+    error_message = "Error when parsing array field with default value and constraints"
+  }
+}
+
+run "with_null_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "array"
+      items = {
+        type = "bool"
+      }
+      default = null
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_default_value_incompatible_with_type_array" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "array"
+      items = {
+        type = "bool"
+      }
+      default = "not-a-list"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_minItems_and_maxItems" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "array"
+      minItems = 10
+      maxItems = 5
+      items = {
+        type = "bool"
+      }
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_items_type" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "array"
+      items = {
+        type = "invalid-type"
+      }
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_object_items_delegates_to_reduced_object_v2" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "array"
+      items = {
+        type = "object"
+        properties = {
+          name = {
+            type = "string"
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.schema.subItem.type == "reduced_object" && output.schema.subItem.version == "v2"
+    error_message = "Error: array items of type object must delegate to reduced_object/v2"
+  }
+}

--- a/tests/schemaProcessor_array_v2_validator.tftest.hcl
+++ b/tests/schemaProcessor_array_v2_validator.tftest.hcl
@@ -1,0 +1,319 @@
+run "without_field_value_without_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "string"
+        version = "v1"
+        subItem = null
+        validations = {
+          minLength         = null
+          maxLength         = null
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = null
+        maxItems          = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_invalid_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "string"
+        version = "v1"
+        subItem = null
+        validations = {
+          minLength         = null
+          maxLength         = null
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = null
+        maxItems          = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = { test = 1 }
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_invalid_value_with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "string"
+        version = "v1"
+        subItem = null
+        validations = {
+          minLength         = null
+          maxLength         = null
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = null
+        maxItems          = null
+        has_default_value = true
+        default_value     = ["a"]
+      }
+    }
+    manifest = { test = 1 }
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_wrong_minItems" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "string"
+        version = "v1"
+        subItem = null
+        validations = {
+          minLength         = null
+          maxLength         = null
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = 3
+        maxItems          = null
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = ["test1"]
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_wrong_maxItems" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "string"
+        version = "v1"
+        subItem = null
+        validations = {
+          minLength         = null
+          maxLength         = null
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = 1
+        maxItems          = 2
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = ["test1", "test2", "test3"]
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_valid_value_without_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type        = "reduced_object"
+        version     = "v2"
+        validations = {}
+        subItem = {
+          integerProperty = {
+            type    = "integer"
+            version = "v1"
+            subItem = null
+            validations = {
+              minimum           = 1
+              maximum           = null
+              has_default_value = false
+              default_value     = null
+            }
+          }
+        }
+      }
+      validations = {
+        minItems          = 1
+        maxItems          = 2
+        has_default_value = false
+        default_value     = null
+      }
+    }
+    manifest = [{
+      integerProperty = 3
+    }]
+  }
+
+  assert {
+    condition     = output.resource == [{ integerProperty = 3 }]
+    error_message = "Error when validating array with minItems and maxItems."
+  }
+}
+
+run "with_valid_value_with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "bool"
+        version = "v1"
+        subItem = null
+        validations = {
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = null
+        maxItems          = null
+        has_default_value = true
+        default_value     = [true]
+      }
+    }
+    manifest = [false, true]
+  }
+
+  assert {
+    condition     = output.resource == [false, true]
+    error_message = "Error: replaced provided value with default value"
+  }
+}
+
+run "without_field_value_with_default_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/array/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "array"
+      version = "v2"
+      subItem = {
+        type    = "bool"
+        version = "v1"
+        subItem = null
+        validations = {
+          has_default_value = false
+          default_value     = null
+        }
+      }
+      validations = {
+        minItems          = null
+        maxItems          = null
+        has_default_value = true
+        default_value     = [true, false]
+      }
+    }
+    manifest = null
+  }
+
+  assert {
+    condition     = output.resource == [true, false]
+    error_message = "Error: did not use default value when field is absent"
+  }
+}


### PR DESCRIPTION
## O que esta PR faz

Cria `schemaProcessor/array/v2/{processor,validator}`, com suporte ao campo `default` opcional (lista de itens). Referencia os primitivos `string/v1`, `integer/v1`, `bool/v1` para itens escalares e `reduced_object/v2` (PR #39) para itens do tipo `object`, seguindo a ordem de dependência planejada (`reduced_array` → `reduced_object` → `array` → `object` → `root_object`).

Quando `default` está ausente, o campo se comporta como obrigatório (compatível com `v0`).

## Por que "v2"

Mesma razão explicada na PR #38 (base da série): "v1" já tem significado próprio, ad-hoc e restrito, dentro do `CustomResourceDefinition/v1alpha2`. Nesse caso específico o `v1alpha2` nunca chegou a emitir `array` com `version = "v1"` (ficou sempre em `v0`), mas mantemos a mesma convenção "v2" adotada pelos demais tipos complexos para não colidir no futuro. O dispatcher `schemaValidation/array` recebe o branch `v2` **adicionado ao lado** do `v0` existente, sem remover nem alterar nada preexistente.

## Dependências

PR 3 de 7. Base: #39 (`reduced_object/v2`). Próxima da pilha: `object/v2`, que vai depender desta.

1. #38 — `reduced_array/v2`
2. #39 — `reduced_object/v2`
3. **esta PR** — `array/v2`
4. #41 — `object/v2`
5. #42 — `root_object/v2`
6. #43 — `reduced_object/v2` — optional
7. #44 — `object/v2` — optional

## Testes

Testes unitários (processor + validator) e de integração encadeada (processor → validator). Suíte completa passando, sem regressões.