### PR TITLE
schemaProcessor/root_object/v2: adiciona suporte a default value em subItems

### DIFF
--- a/schemaProcessor/root_object/v2/processor/main.tf
+++ b/schemaProcessor/root_object/v2/processor/main.tf
@@ -1,0 +1,103 @@
+locals {
+  properties = try({ for key, value in var.manifest.properties : key => value }, {})
+}
+
+module "string" {
+  source   = "../../../string/v1/processor"
+  for_each = toset([for key, value in local.properties : key if try(value.type, null) == "string"])
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.properties.${each.key}"
+  manifest      = var.manifest.properties[each.key]
+}
+
+module "integer" {
+  source   = "../../../integer/v1/processor"
+  for_each = toset([for key, value in local.properties : key if try(value.type, null) == "integer"])
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.properties.${each.key}"
+  manifest      = var.manifest.properties[each.key]
+}
+
+module "bool" {
+  source   = "../../../bool/v1/processor"
+  for_each = toset([for key, value in local.properties : key if try(value.type, null) == "bool"])
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.properties.${each.key}"
+  manifest      = var.manifest.properties[each.key]
+}
+
+module "array" {
+  source   = "../../../array/v2/processor"
+  for_each = toset([for key, value in local.properties : key if try(value.type, null) == "array"])
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.properties.${each.key}"
+  manifest      = var.manifest.properties[each.key]
+}
+
+module "object" {
+  source   = "../../../object/v2/processor"
+  for_each = toset([for key, value in local.properties : key if try(value.type, null) == "object"])
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.properties.${each.key}"
+  manifest      = var.manifest.properties[each.key]
+}
+
+output "schema" {
+  value = {
+    type        = "root_object"
+    version     = "v2"
+    validations = {}
+    subItem = {
+      for key, value in merge(module.string, module.integer, module.bool, module.array, module.object) : key => value.schema
+    }
+  }
+
+  precondition {
+    condition     = can(var.manifest.properties)
+    error_message = <<-EOT
+      Invalid object.
+      The field "${var.field_path}.properties" are required.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = !can(var.manifest.properties) || can(keys(var.manifest.properties))
+    error_message = <<-EOT
+      Invalid "properties" value.
+      The field "${var.field_path}.properties" must be an object.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = length([for key, value in local.properties : key if try(value.type, null) == null]) == 0
+    error_message = <<-EOT
+      Invalid "properties" value.
+      The field "${var.field_path}.properties" must have a "type" field.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition = alltrue([
+      for key, value in local.properties : contains(["string", "integer", "bool", "array", "object"], value.type)
+      if can(value.type)
+    ])
+    error_message = <<-EOT
+      Invalid propertie "type".
+      The field "${var.field_path}.properties.*.type" must be one of "string", "integer", "bool", "array" or "object".
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaProcessor/root_object/v2/processor/variables.tf
+++ b/schemaProcessor/root_object/v2/processor/variables.tf
@@ -1,0 +1,15 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}

--- a/schemaProcessor/root_object/v2/validator/main.tf
+++ b/schemaProcessor/root_object/v2/validator/main.tf
@@ -1,0 +1,94 @@
+locals {
+  properties = keys(var.schema.subItem)
+  missing_properties = [
+    for property in local.properties : property
+    if !can(var.manifest[property])
+    && !try(var.schema.subItem[property].validations.has_default_value, false)
+  ]
+}
+
+module "string" {
+  source   = "../../../../schemaValidation/string"
+  for_each = { for k, v in var.schema.subItem : k => v if v.type == "string" && !contains(local.missing_properties, k) }
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.${each.key}"
+  manifest      = try(var.manifest[each.key], null)
+  schema        = each.value
+}
+
+module "integer" {
+  source   = "../../../../schemaValidation/integer"
+  for_each = { for k, v in var.schema.subItem : k => v if v.type == "integer" && !contains(local.missing_properties, k) }
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.${each.key}"
+  manifest      = try(var.manifest[each.key], null)
+  schema        = each.value
+}
+
+module "bool" {
+  source   = "../../../../schemaValidation/bool"
+  for_each = { for k, v in var.schema.subItem : k => v if v.type == "bool" && !contains(local.missing_properties, k) }
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.${each.key}"
+  manifest      = try(var.manifest[each.key], null)
+  schema        = each.value
+}
+
+module "array" {
+  source   = "../../../../schemaValidation/array"
+  for_each = { for k, v in var.schema.subItem : k => v if v.type == "array" && !contains(local.missing_properties, k) }
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.${each.key}"
+  manifest      = try(var.manifest[each.key], null)
+  schema        = each.value
+}
+
+module "object" {
+  source   = "../../../../schemaValidation/object"
+  for_each = { for k, v in var.schema.subItem : k => v if v.type == "object" && !contains(local.missing_properties, k) }
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = "${var.field_path}.${each.key}"
+  manifest      = try(var.manifest[each.key], null)
+  schema        = each.value
+}
+
+output "resource" {
+  value = { for k, v in merge(module.string, module.integer, module.bool, module.array, module.object) : k => v.resource }
+
+  precondition {
+    condition     = var.manifest != null
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The property "${var.field_path}" can not be null.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = can(keys(var.manifest))
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The type of the property "${var.field_path}" must be object.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = length(local.missing_properties) == 0
+    error_message = <<-EOT
+      Invalid resource manifest!
+      The field "${var.field_path}" is missing the following properties: ${join(", ", local.missing_properties)}.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
+    EOT
+  }
+}

--- a/schemaProcessor/root_object/v2/validator/variables.tf
+++ b/schemaProcessor/root_object/v2/validator/variables.tf
@@ -1,0 +1,19 @@
+variable "metadata_name" {
+  type = string
+}
+
+variable "path" {
+  type = string
+}
+
+variable "field_path" {
+  type = string
+}
+
+variable "manifest" {
+  type = any
+}
+
+variable "schema" {
+  type = any
+}

--- a/schemaValidation/root_object/main.tf
+++ b/schemaValidation/root_object/main.tf
@@ -20,11 +20,23 @@ module "v1" {
   schema        = var.schema
 }
 
+module "v2" {
+  source = "../../schemaProcessor/root_object/v2/validator/"
+  count  = var.schema.version == "v2" ? 1 : 0
+
+  metadata_name = var.metadata_name
+  path          = var.path
+  field_path    = var.field_path
+  manifest      = var.manifest
+  schema        = var.schema
+}
+
 output "resource" {
   value = one(
     concat(
       module.v0[*].resource,
       module.v1[*].resource,
+      module.v2[*].resource,
     )
   )
 }

--- a/tests/schemaProcessor_root_object_v2_integration.tftest.hcl
+++ b/tests/schemaProcessor_root_object_v2_integration.tftest.hcl
@@ -1,0 +1,125 @@
+run "required_property_with_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    manifest = {
+      type = "object"
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+}
+
+run "required_property_manifest_provides_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.required_property_with_value.schema
+    manifest = {
+      name = "hello"
+    }
+  }
+
+  assert {
+    condition     = output.resource == { name = "hello" }
+    error_message = "Error: did not return the provided value for a required property"
+  }
+}
+
+run "required_property_manifest_missing_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.required_property_with_value.schema
+    manifest      = {}
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "optional_property_with_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    manifest = {
+      type = "object"
+      properties = {
+        name = {
+          type    = "string"
+          default = "fallback"
+        }
+      }
+    }
+  }
+}
+
+run "optional_property_manifest_missing_uses_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_property_with_default.schema
+    manifest      = {}
+  }
+
+  assert {
+    condition     = output.resource == { name = "fallback" }
+    error_message = "Error: did not use default value when property is absent"
+  }
+}
+
+run "optional_property_manifest_overrides_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_property_with_default.schema
+    manifest = {
+      name = "provided"
+    }
+  }
+
+  assert {
+    condition     = output.resource == { name = "provided" }
+    error_message = "Error: replaced provided value with default"
+  }
+}

--- a/tests/schemaProcessor_root_object_v2_processor.tftest.hcl
+++ b/tests/schemaProcessor_root_object_v2_processor.tftest.hcl
@@ -1,0 +1,271 @@
+run "without_properties" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "object"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_invalid_properties" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type       = "object"
+      properties = "invalid"
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_properties_missing_type" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "object"
+      properties = {
+        test = {}
+      }
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_properties_invalid_type" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "object"
+      properties = {
+        test = {
+          type = "invalid"
+        }
+      }
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_properties_without_default_values" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "object"
+      properties = {
+        boolProperty = {
+          type = "bool"
+        }
+        stringProperty = {
+          type      = "string"
+          minLength = 1
+        }
+        integerProperty = {
+          type    = "integer"
+          minimum = 1
+        }
+        arrayProperty = {
+          type = "array"
+          items = {
+            type      = "string"
+            minLength = 1
+          }
+        }
+        objectProperty = {
+          type = "object"
+          properties = {
+            stringProperty = {
+              type      = "string"
+              minLength = 1
+            }
+          }
+        }
+      }
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        boolProperty = {
+          type    = "bool"
+          version = "v1"
+          subItem = null
+          validations = {
+            has_default_value = false
+            default_value     = null
+          }
+        }
+        stringProperty = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = 1
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+        integerProperty = {
+          type    = "integer"
+          version = "v1"
+          subItem = null
+          validations = {
+            minimum           = 1
+            maximum           = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+        arrayProperty = {
+          type    = "array"
+          version = "v2"
+          subItem = {
+            type    = "string"
+            version = "v1"
+            subItem = null
+            validations = {
+              minLength         = 1
+              maxLength         = null
+              has_default_value = false
+              default_value     = null
+            }
+          }
+          validations = {
+            minItems          = null
+            maxItems          = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+        objectProperty = {
+          type        = "object"
+          version     = "v2"
+          validations = {}
+          subItem = {
+            stringProperty = {
+              type    = "string"
+              version = "v1"
+              subItem = null
+              validations = {
+                minLength         = 1
+                maxLength         = null
+                has_default_value = false
+                default_value     = null
+              }
+            }
+          }
+        }
+      }
+    }
+    error_message = "Error when parsing root_object with properties without default values."
+  }
+}
+
+run "with_properties_with_default_values" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "object"
+      properties = {
+        boolProperty = {
+          type    = "bool"
+          default = true
+        }
+        stringProperty = {
+          type    = "string"
+          default = "fallback"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition = output.schema == {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        boolProperty = {
+          type    = "bool"
+          version = "v1"
+          subItem = null
+          validations = {
+            has_default_value = true
+            default_value     = true
+          }
+        }
+        stringProperty = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = true
+            default_value     = "fallback"
+          }
+        }
+      }
+    }
+    error_message = "Error when parsing root_object with properties with default values."
+  }
+}

--- a/tests/schemaProcessor_root_object_v2_validator.tftest.hcl
+++ b/tests/schemaProcessor_root_object_v2_validator.tftest.hcl
@@ -1,0 +1,311 @@
+run "missing_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        stringProperty = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_invalid_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        stringProperty = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = [1]
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_missing_required_property" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        stringProperty = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = {}
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "with_valid_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        stringProperty = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = 1
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+        integerProperty = {
+          type    = "integer"
+          version = "v1"
+          subItem = null
+          validations = {
+            minimum           = 1
+            maximum           = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+        boolProperty = {
+          type    = "bool"
+          version = "v1"
+          subItem = null
+          validations = {
+            has_default_value = false
+            default_value     = null
+          }
+        }
+        objectProperty = {
+          type        = "object"
+          version     = "v2"
+          validations = {}
+          subItem = {
+            stringProperty = {
+              type    = "string"
+              version = "v1"
+              subItem = null
+              validations = {
+                minLength         = 1
+                maxLength         = null
+                has_default_value = false
+                default_value     = null
+              }
+            }
+          }
+        }
+      }
+    }
+    manifest = {
+      stringProperty  = "test"
+      integerProperty = 1
+      boolProperty    = true
+      objectProperty = {
+        stringProperty = "test"
+      }
+    }
+  }
+
+  assert {
+    condition = output.resource == {
+      stringProperty  = "test"
+      integerProperty = 1
+      boolProperty    = true
+      objectProperty = {
+        stringProperty = "test"
+      }
+    }
+    error_message = "Error when validating root_object."
+  }
+}
+
+run "with_missing_bool_property_uses_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        active = {
+          type    = "bool"
+          version = "v1"
+          subItem = null
+          validations = {
+            has_default_value = true
+            default_value     = true
+          }
+        }
+      }
+    }
+    manifest = {}
+  }
+
+  assert {
+    condition     = output.resource == { active = true }
+    error_message = "Error: did not use default value for missing bool property"
+  }
+}
+
+run "with_missing_string_property_uses_default" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = true
+            default_value     = "fallback"
+          }
+        }
+      }
+    }
+    manifest = {}
+  }
+
+  assert {
+    condition     = output.resource == { name = "fallback" }
+    error_message = "Error: did not use default value for missing string property"
+  }
+}
+
+run "with_missing_object_property_fails" {
+  command = plan
+  module {
+    source = "./schemaProcessor/root_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type        = "root_object"
+      version     = "v2"
+      validations = {}
+      subItem = {
+        objectProperty = {
+          type        = "object"
+          version     = "v2"
+          validations = {}
+          subItem = {
+            stringProperty = {
+              type    = "string"
+              version = "v1"
+              subItem = null
+              validations = {
+                minLength         = null
+                maxLength         = null
+                has_default_value = false
+                default_value     = null
+              }
+            }
+          }
+        }
+      }
+    }
+    manifest = {}
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}


### PR DESCRIPTION
## O que esta PR faz

Cria `schemaProcessor/root_object/v2/{processor,validator}`, referenciando `string/v1`, `integer/v1`, `bool/v1`, `array/v2` (PR #40) e `object/v2` (PR #41). É o nó raiz do schema (`specSchema` de uma CRD) — diferente dos outros tipos complexos da série, aceita `object` diretamente (não apenas via `reduced_object`), delegando pra `object/v2` a resolução de objetos aninhados.

**Importante:** `root_object` em si **não ganha** campo `default` nem `optional` — não faz sentido ele ter, já que não é propriedade de nada (é a raiz). O que esta PR faz é só trocar suas referências internas de `array/v0`+`object/v0` para `array/v2`+`object/v2`, propagando a capacidade de `default`/`optional` para toda a árvore de propriedades abaixo da raiz.

## Por que "v2"

Mesma razão explicada na PR #38 (base da série): "v1" já tem significado próprio, ad-hoc e restrito, dentro do `CustomResourceDefinition/v1alpha2` — `root_object` já emite `version = "v1"` de lá, cobrindo só `bool` com `default`. O dispatcher `schemaValidation/root_object` recebe o branch `v2` **adicionado ao lado** do `v0` e do `v1` legado existentes, sem remover nem alterar nada preexistente (o `v1` legado continua servindo o `v1alpha2`).

Este é o **último tipo complexo da série "v2"** (default value) — com esta PR, toda a árvore `reduced_array → reduced_object → array → object → root_object` está completa em `v2`. Ainda não é alcançável por quem escreve CRDs: nem `v1alpha1` nem `v1alpha2` referenciam `root_object/v2` hoje — isso só passa a valer com um futuro `v1alpha3`, fora do escopo desta série.

## Dependências

PR 5 de 7. Base: #41 (`object/v2`). Próxima da pilha: #43 (`reduced_object/v2` ganha `optional`).

1. #38 — `reduced_array/v2`
2. #39 — `reduced_object/v2`
3. #40 — `array/v2`
4. #41 — `object/v2`
5. **esta PR** — `root_object/v2`
6. #43 — `reduced_object/v2` — optional
7. #44 — `object/v2` — optional

## Testes

Testes unitários (processor + validator) e de integração encadeada (processor → validator). Suíte completa passando, sem regressões.