### PR TITLE
schemaProcessor/reduced_object/v2: adiciona suporte a optional

### DIFF
--- a/schemaProcessor/reduced_object/v2/processor/main.tf
+++ b/schemaProcessor/reduced_object/v2/processor/main.tf
@@ -1,5 +1,7 @@
 locals {
-  properties = try({ for key, value in var.manifest.properties : key => value }, {})
+  properties                    = try({ for key, value in var.manifest.properties : key => value }, {})
+  declared_optional_field       = contains(keys(var.manifest), "optional")
+  has_compatible_optional_value = can(tobool(try(var.manifest.optional, false)))
 }
 
 module "string" {
@@ -44,9 +46,11 @@ module "reduced_array" {
 
 output "schema" {
   value = {
-    type        = "reduced_object"
-    version     = "v2"
-    validations = {}
+    type    = "reduced_object"
+    version = "v2"
+    validations = {
+      optional = try(tobool(var.manifest.optional), false)
+    }
     subItem = {
       for key, value in merge(module.string, module.integer, module.bool, module.reduced_array) : key => value.schema
     }
@@ -88,6 +92,24 @@ output "schema" {
       Invalid propertie "type".
       The field "${var.field_path}.properties.*.type" must be one of "string", "integer", "bool" or "array".
       (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = local.has_compatible_optional_value
+    error_message = <<-EOT
+      Invalid "optional" value.
+      The field "${var.field_path}.optional" must be a bool.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = !(local.declared_optional_field && try(tobool(var.manifest.optional), false) && contains(keys(var.manifest), "default"))
+    error_message = <<-EOT
+      Invalid Manifest!
+      The field "${var.field_path}" can't have both "optional: true" and "default" set.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
     EOT
   }
 }

--- a/schemaProcessor/reduced_object/v2/validator/main.tf
+++ b/schemaProcessor/reduced_object/v2/validator/main.tf
@@ -1,4 +1,5 @@
 locals {
+  optional   = var.schema.validations.optional
   properties = keys(var.schema.subItem)
   missing_properties = [
     for property in local.properties : property
@@ -52,19 +53,19 @@ module "reduced_array" {
 }
 
 output "resource" {
-  value = { for k, v in merge(module.string, module.integer, module.bool, module.reduced_array) : k => v.resource }
+  value = var.manifest != null ? { for k, v in merge(module.string, module.integer, module.bool, module.reduced_array) : k => v.resource } : null
 
   precondition {
-    condition     = var.manifest != null
+    condition     = var.manifest != null || local.optional
     error_message = <<-EOT
       Invalid resource manifest!
-      The property "${var.field_path}" can not be null.
+      The property "${var.field_path}" can not be null (and is not optional).
       (metadata.name: "${var.metadata_name}"; path: "${var.path}")
     EOT
   }
 
   precondition {
-    condition     = can(keys(var.manifest))
+    condition     = var.manifest == null || can(keys(var.manifest))
     error_message = <<-EOT
       Invalid resource manifest!
       The type of the property "${var.field_path}" must be object.
@@ -73,7 +74,7 @@ output "resource" {
   }
 
   precondition {
-    condition     = length(local.missing_properties) == 0
+    condition     = var.manifest == null || length(local.missing_properties) == 0
     error_message = <<-EOT
       Invalid resource manifest!
       The field "${var.field_path}" is missing the following properties: ${join(", ", local.missing_properties)}.

--- a/tests/schemaProcessor_array_v2_validator.tftest.hcl
+++ b/tests/schemaProcessor_array_v2_validator.tftest.hcl
@@ -207,9 +207,11 @@ run "with_valid_value_without_default_value" {
       type    = "array"
       version = "v2"
       subItem = {
-        type        = "reduced_object"
-        version     = "v2"
-        validations = {}
+        type    = "reduced_object"
+        version = "v2"
+        validations = {
+          optional = false
+        }
         subItem = {
           integerProperty = {
             type    = "integer"

--- a/tests/schemaProcessor_object_v2_processor.tftest.hcl
+++ b/tests/schemaProcessor_object_v2_processor.tftest.hcl
@@ -190,9 +190,11 @@ run "with_properties_without_default_values" {
           }
         }
         objectProperty = {
-          type        = "reduced_object"
-          version     = "v2"
-          validations = {}
+          type    = "reduced_object"
+          version = "v2"
+          validations = {
+            optional = false
+          }
           subItem = {
             stringProperty = {
               type    = "string"

--- a/tests/schemaProcessor_object_v2_validator.tftest.hcl
+++ b/tests/schemaProcessor_object_v2_validator.tftest.hcl
@@ -153,9 +153,11 @@ run "with_valid_value" {
           }
         }
         reducedObjectProperty = {
-          type        = "reduced_object"
-          version     = "v2"
-          validations = {}
+          type    = "reduced_object"
+          version = "v2"
+          validations = {
+            optional = false
+          }
           subItem = {
             stringProperty = {
               type    = "string"

--- a/tests/schemaProcessor_reduced_object_v2_integration.tftest.hcl
+++ b/tests/schemaProcessor_reduced_object_v2_integration.tftest.hcl
@@ -123,3 +123,67 @@ run "optional_property_manifest_overrides_default" {
     error_message = "Error: replaced provided value with default"
   }
 }
+
+run "optional_object_with_manifest_present" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    manifest = {
+      type     = "object"
+      optional = true
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+}
+
+run "optional_object_manifest_absent_resolves_to_null" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_object_with_manifest_present.schema
+    manifest      = null
+  }
+
+  assert {
+    condition     = output.resource == null
+    error_message = "Error: optional object with absent manifest should resolve to null"
+  }
+}
+
+run "optional_object_manifest_present_validates_normally" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_object_with_manifest_present.schema
+    manifest = {
+      name = "hello"
+    }
+  }
+
+  assert {
+    condition     = output.resource == { name = "hello" }
+    error_message = "Error: optional object with present manifest should validate normally"
+  }
+}

--- a/tests/schemaProcessor_reduced_object_v2_processor.tftest.hcl
+++ b/tests/schemaProcessor_reduced_object_v2_processor.tftest.hcl
@@ -121,9 +121,11 @@ run "with_properties_without_default_values" {
 
   assert {
     condition = output.schema == {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         boolProperty = {
           type    = "bool"
@@ -214,9 +216,11 @@ run "with_properties_with_default_values" {
 
   assert {
     condition = output.schema == {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         boolProperty = {
           type    = "bool"
@@ -253,4 +257,138 @@ run "with_properties_with_default_values" {
     }
     error_message = "Error when parsing reduced_object with properties with default values."
   }
+}
+
+run "without_optional_defaults_to_false" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "object"
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.schema.validations.optional == false
+    error_message = "Error: optional should default to false when absent"
+  }
+}
+
+run "with_optional_true" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "object"
+      optional = true
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.schema.validations.optional == true
+    error_message = "Error: optional should be true when declared"
+  }
+}
+
+run "with_optional_true_and_required_internal_fields_is_valid" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "object"
+      optional = true
+      properties = {
+        name = {
+          type      = "string"
+          minLength = 1
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.schema.validations.optional == true
+    error_message = "Error: optional:true with required internal fields should be valid (orthogonal rules)"
+  }
+}
+
+run "with_invalid_optional_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "object"
+      optional = "not-a-bool"
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_optional_and_default_together_is_invalid" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "object"
+      optional = true
+      default  = {}
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
 }

--- a/tests/schemaProcessor_reduced_object_v2_validator.tftest.hcl
+++ b/tests/schemaProcessor_reduced_object_v2_validator.tftest.hcl
@@ -9,9 +9,11 @@ run "missing_value" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"
@@ -45,9 +47,11 @@ run "with_invalid_value" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"
@@ -81,9 +85,11 @@ run "with_missing_required_property" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"
@@ -117,9 +123,11 @@ run "with_valid_value" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"
@@ -182,9 +190,11 @@ run "with_missing_bool_property_uses_default" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         active = {
           type    = "bool"
@@ -217,9 +227,11 @@ run "with_null_bool_property_uses_default" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         active = {
           type    = "bool"
@@ -254,9 +266,11 @@ run "with_missing_string_property_uses_default" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         name = {
           type    = "string"
@@ -291,9 +305,11 @@ run "with_missing_integer_property_uses_default" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         replicas = {
           type    = "integer"
@@ -328,9 +344,11 @@ run "with_missing_reduced_array_property_uses_default" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         tags = {
           type    = "reduced_array"
@@ -362,4 +380,160 @@ run "with_missing_reduced_array_property_uses_default" {
     condition     = output.resource == { tags = ["default-tag"] }
     error_message = "Error: did not use default value for missing reduced_array property"
   }
+}
+
+run "optional_and_manifest_null_returns_null" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = true
+      }
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = null
+  }
+
+  assert {
+    condition     = output.resource == null
+    error_message = "Error: optional reduced_object with absent manifest should resolve to null"
+  }
+}
+
+run "not_optional_and_manifest_null_fails" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "optional_and_manifest_present_validates_normally" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = true
+      }
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = {
+      name = "hello"
+    }
+  }
+
+  assert {
+    condition     = output.resource == { name = "hello" }
+    error_message = "Error: optional reduced_object with present manifest should validate normally"
+  }
+}
+
+run "optional_and_manifest_present_but_missing_required_property_fails" {
+  command = plan
+  module {
+    source = "./schemaProcessor/reduced_object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = true
+      }
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = {}
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
 }

--- a/tests/schemaValidation_reduced_object.tftest.hcl
+++ b/tests/schemaValidation_reduced_object.tftest.hcl
@@ -125,9 +125,11 @@ run "can_parse_reduced_object_v2" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "reduced_object"
-      version     = "v2"
-      validations = {}
+      type    = "reduced_object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"


### PR DESCRIPTION
## O que esta PR faz

Adiciona o campo `optional: true/false` em `schemaProcessor/reduced_object/v2`: quando `optional = true`, a propriedade do tipo `reduced_object` pode faltar inteira do manifesto (equivalente a "objeto ausente"), em vez de exigir que cada sub-propriedade tenha seu próprio `default`. Sai como `validations.optional` no schema de saída, consumido pelo validator.

Duas preconditions novas no processor:
- `optional` precisa ser um bool quando declarado.
- `optional: true` e `default` não podem coexistir no mesmo campo (ambíguo — qual prevalece?).

## Por que agora, e não junto com o `v2` original

Foi decisão explícita adiar `optional` pra depois da migração estrutural de todos os 5 tipos complexos (`v0` → `v2` com `default`) — ver PR #38/#39. A ideia era não misturar as duas features na mesma rodada. Com a árvore `v2` completa (PR #45, `root_object/v2`), esta e a próxima PR fecham o escopo planejado adicionando `optional`.

## Dependências

PR 6 de 7. Base: #42 (`root_object/v2`). Próxima da pilha: #44 (`object/v2` ganha `optional`), que depende desta.

1. #38 — `reduced_array/v2`
2. #39 — `reduced_object/v2`
3. #40 — `array/v2`
4. #41 — `object/v2`
5. `root_object/v2`
6. **esta PR** — `reduced_object/v2` — optional
7. #44 — `object/v2` — optional

## Testes

Testes novos cobrindo: objeto ausente com `optional: true` (aceito), objeto ausente com `optional: false`/omitido (falha), `optional` com valor não-bool (falha), `optional: true` combinado com `default` (falha). Suíte completa passando, sem regressões.