### PR TITLE
schemaProcessor/object/v2: adiciona suporte a optional

### DIFF
--- a/schemaProcessor/object/v2/processor/main.tf
+++ b/schemaProcessor/object/v2/processor/main.tf
@@ -1,5 +1,7 @@
 locals {
-  properties = try({ for key, value in var.manifest.properties : key => value }, {})
+  properties                    = try({ for key, value in var.manifest.properties : key => value }, {})
+  declared_optional_field       = contains(keys(var.manifest), "optional")
+  has_compatible_optional_value = can(tobool(try(var.manifest.optional, false)))
 }
 
 module "string" {
@@ -54,9 +56,11 @@ module "reduced_object" {
 
 output "schema" {
   value = {
-    type        = "object"
-    version     = "v2"
-    validations = {}
+    type    = "object"
+    version = "v2"
+    validations = {
+      optional = try(tobool(var.manifest.optional), false)
+    }
     subItem = {
       for key, value in merge(module.string, module.integer, module.bool, module.array, module.reduced_object) : key => value.schema
     }
@@ -98,6 +102,24 @@ output "schema" {
       Invalid propertie "type".
       The field "${var.field_path}.properties.*.type" must be one of "string", "integer", "bool", "array" or "object".
       (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = local.has_compatible_optional_value
+    error_message = <<-EOT
+      Invalid "optional" value.
+      The field "${var.field_path}.optional" must be a bool.
+      (metadata.name: "${var.metadata_name}", path: "${var.path}")
+    EOT
+  }
+
+  precondition {
+    condition     = !(local.declared_optional_field && try(tobool(var.manifest.optional), false) && contains(keys(var.manifest), "default"))
+    error_message = <<-EOT
+      Invalid Manifest!
+      The field "${var.field_path}" can't have both "optional: true" and "default" set.
+      (metadata.name: "${var.metadata_name}"; path: "${var.path}")
     EOT
   }
 }

--- a/schemaProcessor/object/v2/validator/main.tf
+++ b/schemaProcessor/object/v2/validator/main.tf
@@ -1,4 +1,5 @@
 locals {
+  optional   = var.schema.validations.optional
   properties = keys(var.schema.subItem)
   missing_properties = [
     for property in local.properties : property
@@ -63,19 +64,19 @@ module "reduced_object" {
 }
 
 output "resource" {
-  value = { for k, v in merge(module.string, module.integer, module.bool, module.array, module.reduced_object) : k => v.resource }
+  value = var.manifest != null ? { for k, v in merge(module.string, module.integer, module.bool, module.array, module.reduced_object) : k => v.resource } : null
 
   precondition {
-    condition     = var.manifest != null
+    condition     = var.manifest != null || local.optional
     error_message = <<-EOT
       Invalid resource manifest!
-      The property "${var.field_path}" can not be null.
+      The property "${var.field_path}" can not be null (and is not optional).
       (metadata.name: "${var.metadata_name}"; path: "${var.path}")
     EOT
   }
 
   precondition {
-    condition     = can(keys(var.manifest))
+    condition     = var.manifest == null || can(keys(var.manifest))
     error_message = <<-EOT
       Invalid resource manifest!
       The type of the property "${var.field_path}" must be object.
@@ -84,7 +85,7 @@ output "resource" {
   }
 
   precondition {
-    condition     = length(local.missing_properties) == 0
+    condition     = var.manifest == null || length(local.missing_properties) == 0
     error_message = <<-EOT
       Invalid resource manifest!
       The field "${var.field_path}" is missing the following properties: ${join(", ", local.missing_properties)}.

--- a/tests/schemaProcessor_object_v2_integration.tftest.hcl
+++ b/tests/schemaProcessor_object_v2_integration.tftest.hcl
@@ -123,3 +123,67 @@ run "optional_property_manifest_overrides_default" {
     error_message = "Error: replaced provided value with default"
   }
 }
+
+run "optional_object_with_manifest_present" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    manifest = {
+      type     = "object"
+      optional = true
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+}
+
+run "optional_object_manifest_absent_resolves_to_null" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_object_with_manifest_present.schema
+    manifest      = null
+  }
+
+  assert {
+    condition     = output.resource == null
+    error_message = "Error: optional object with absent manifest should resolve to null"
+  }
+}
+
+run "optional_object_manifest_present_validates_normally" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema        = run.optional_object_with_manifest_present.schema
+    manifest = {
+      name = "hello"
+    }
+  }
+
+  assert {
+    condition     = output.resource == { name = "hello" }
+    error_message = "Error: optional object with present manifest should validate normally"
+  }
+}

--- a/tests/schemaProcessor_object_v2_processor.tftest.hcl
+++ b/tests/schemaProcessor_object_v2_processor.tftest.hcl
@@ -133,9 +133,11 @@ run "with_properties_without_default_values" {
 
   assert {
     condition = output.schema == {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         boolProperty = {
           type    = "bool"
@@ -253,9 +255,11 @@ run "with_properties_with_default_values" {
 
   assert {
     condition = output.schema == {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         boolProperty = {
           type    = "bool"
@@ -311,4 +315,110 @@ run "with_properties_with_default_values" {
     }
     error_message = "Error when parsing object with properties with default values."
   }
+}
+
+run "without_optional_defaults_to_false" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type = "object"
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.schema.validations.optional == false
+    error_message = "Error: optional should default to false when absent"
+  }
+}
+
+run "with_optional_true" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "object"
+      optional = true
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+
+  assert {
+    condition     = output.schema.validations.optional == true
+    error_message = "Error: optional should be true when declared"
+  }
+}
+
+run "with_invalid_optional_value" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "object"
+      optional = "not-a-bool"
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
+}
+
+run "with_optional_and_default_together_is_invalid" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/processor"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.versions[0].specSchema.test"
+    manifest = {
+      type     = "object"
+      optional = true
+      default  = {}
+      properties = {
+        name = {
+          type = "string"
+        }
+      }
+    }
+  }
+
+  expect_failures = [
+    output.schema,
+  ]
 }

--- a/tests/schemaProcessor_object_v2_validator.tftest.hcl
+++ b/tests/schemaProcessor_object_v2_validator.tftest.hcl
@@ -9,9 +9,11 @@ run "missing_value" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"
@@ -45,9 +47,11 @@ run "with_invalid_value" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"
@@ -81,9 +85,11 @@ run "with_missing_required_property" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"
@@ -117,9 +123,11 @@ run "with_valid_value" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         stringProperty = {
           type    = "string"
@@ -208,9 +216,11 @@ run "with_missing_bool_property_uses_default" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         active = {
           type    = "bool"
@@ -243,9 +253,11 @@ run "with_missing_string_property_uses_default" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         name = {
           type    = "string"
@@ -280,9 +292,11 @@ run "with_missing_array_property_uses_default" {
     path          = "."
     field_path    = "spec.test"
     schema = {
-      type        = "object"
-      version     = "v2"
-      validations = {}
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
       subItem = {
         tags = {
           type    = "array"
@@ -314,4 +328,160 @@ run "with_missing_array_property_uses_default" {
     condition     = output.resource == { tags = ["default-tag"] }
     error_message = "Error: did not use default value for missing array property"
   }
+}
+
+run "optional_and_manifest_null_returns_null" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = true
+      }
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = null
+  }
+
+  assert {
+    condition     = output.resource == null
+    error_message = "Error: optional object with absent manifest should resolve to null"
+  }
+}
+
+run "not_optional_and_manifest_null_fails" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = false
+      }
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = null
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
+}
+
+run "optional_and_manifest_present_validates_normally" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = true
+      }
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = {
+      name = "hello"
+    }
+  }
+
+  assert {
+    condition     = output.resource == { name = "hello" }
+    error_message = "Error: optional object with present manifest should validate normally"
+  }
+}
+
+run "optional_and_manifest_present_but_missing_required_property_fails" {
+  command = plan
+  module {
+    source = "./schemaProcessor/object/v2/validator/"
+  }
+
+  variables {
+    metadata_name = "test"
+    path          = "."
+    field_path    = "spec.test"
+    schema = {
+      type    = "object"
+      version = "v2"
+      validations = {
+        optional = true
+      }
+      subItem = {
+        name = {
+          type    = "string"
+          version = "v1"
+          subItem = null
+          validations = {
+            minLength         = null
+            maxLength         = null
+            has_default_value = false
+            default_value     = null
+          }
+        }
+      }
+    }
+    manifest = {}
+  }
+
+  expect_failures = [
+    output.resource,
+  ]
 }

--- a/tests/schemaProcessor_root_object_v2_processor.tftest.hcl
+++ b/tests/schemaProcessor_root_object_v2_processor.tftest.hcl
@@ -190,9 +190,11 @@ run "with_properties_without_default_values" {
           }
         }
         objectProperty = {
-          type        = "object"
-          version     = "v2"
-          validations = {}
+          type    = "object"
+          version = "v2"
+          validations = {
+            optional = false
+          }
           subItem = {
             stringProperty = {
               type    = "string"

--- a/tests/schemaProcessor_root_object_v2_validator.tftest.hcl
+++ b/tests/schemaProcessor_root_object_v2_validator.tftest.hcl
@@ -153,9 +153,11 @@ run "with_valid_value" {
           }
         }
         objectProperty = {
-          type        = "object"
-          version     = "v2"
-          validations = {}
+          type    = "object"
+          version = "v2"
+          validations = {
+            optional = false
+          }
           subItem = {
             stringProperty = {
               type    = "string"
@@ -283,9 +285,11 @@ run "with_missing_object_property_fails" {
       validations = {}
       subItem = {
         objectProperty = {
-          type        = "object"
-          version     = "v2"
-          validations = {}
+          type    = "object"
+          version = "v2"
+          validations = {
+            optional = false
+          }
           subItem = {
             stringProperty = {
               type    = "string"


### PR DESCRIPTION
## O que esta PR faz

Mesma feature da PR anterior (#6, `reduced_object/v2` — optional), agora em `schemaProcessor/object/v2`: campo `optional: true/false` permitindo que a propriedade do tipo `object` falte inteira do manifesto. Mesmas duas preconditions (tipo bool; incompatível com `default` no mesmo campo).

## Dependências

PR 7 de 7 — **última da série**. Base: PR 6 (`reduced_object/v2` — optional).

1. #38 — `reduced_array/v2`
2. #39 — `reduced_object/v2`
3. #40 — `array/v2`
4. #41 — `object/v2`
5. `root_object/v2`
6. `reduced_object/v2` — optional
7. **esta PR** — `object/v2` — optional

Com esta PR, a série planejada de 7 PRs está completa. Próximo passo (fora do escopo desta série): iniciar `v1alpha3`, que é o que de fato torna toda essa árvore `v2` (default value + optional) alcançável por quem escreve CRDs.

## Testes

Testes novos cobrindo os mesmos cenários da PR #6, aplicados a `object`. Suíte completa passando, sem regressões.
